### PR TITLE
Fix for HA 2025.8

### DIFF
--- a/custom_components/etekcity_fitness_scale_ble/coordinator.py
+++ b/custom_components/etekcity_fitness_scale_ble/coordinator.py
@@ -259,6 +259,7 @@ class BleakScannerESPHome(BaseBleakScanner):
             adv.name or "",
             adv.manufacturer_data,
             advertisement_data,
+            adv,
         )
 
         # Call the detection callbacks
@@ -317,6 +318,7 @@ class BleakScannerESPHome(BaseBleakScanner):
                 local_name or "",
                 manufacturer_data,
                 advertisement_data,
+                adv,
             )
 
             # Call the detection callbacks


### PR DESCRIPTION
The integration wasn't working anymore since upgrade to HA 2025.8, after diging logs there was an issue with paramters on create_or_update_device calls (which are requiring one more it seems).
So I added them, since it works again

Addition of adv parameter on both create_or_update_device calls.