### PR TITLE
Add 'Drop Unassigned Measurements' advanced setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ When a new measurement is received, the integration attempts to automatically as
 1. **Weight History:** The measurement is compared against each user's weight history.
 2. **Location:** If a user profile is linked to a Home Assistant `person` entity, the integration checks if that person is `home`. Users who are `not_home` are excluded from automatic assignment.
 
-If a single user is a clear match, the measurement is assigned automatically.
+If a single user is a clear match, the measurement is assigned automatically, by default.
 
 ### Ambiguous Measurements
 
@@ -104,6 +104,10 @@ If the measurement is ambiguous (e.g., two users have similar weights, or a new 
   - "Not me" - Dismisses your notification (measurement remains available for others)
 
 - **Persistent Notifications:** A notification appears in the Home Assistant notifications panel with instructions to manually assign the measurement using the `assign_measurement` service.
+
+### Dropping Guest/Pet/Unknown Measurements
+
+If the measurement is ambiguous and cannot be automatically assigned to a user and the "Drop Unassigned Measurements" advanced setting is enabled, then the measurement will be silently dropped. This is ideal for ad-hoc measurements made by any person or thing not already configured and won't be configured.
 
 ### Managing Users
 

--- a/custom_components/etekcity_fitness_scale_ble/config_flow.py
+++ b/custom_components/etekcity_fitness_scale_ble/config_flow.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_BODY_METRICS_ENABLED,
     CONF_CALC_BODY_METRICS,
     CONF_CREATED_AT,
+    CONF_DROP_UNASSIGNED_MEASUREMENTS,
     CONF_ENABLE_LIBRARY_LOGGING,
     CONF_FEET,
     CONF_HEIGHT,
@@ -1497,6 +1498,9 @@ class ScaleOptionsFlow(OptionsFlow):
                 CONF_HISTORY_RETENTION_DAYS: user_input[CONF_HISTORY_RETENTION_DAYS],
                 CONF_MAX_HISTORY_SIZE: user_input[CONF_MAX_HISTORY_SIZE],
                 CONF_ENABLE_LIBRARY_LOGGING: user_input[CONF_ENABLE_LIBRARY_LOGGING],
+                CONF_DROP_UNASSIGNED_MEASUREMENTS: user_input[
+                    CONF_DROP_UNASSIGNED_MEASUREMENTS
+                ],
             }
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=new_data
@@ -1510,6 +1514,9 @@ class ScaleOptionsFlow(OptionsFlow):
         # Get current values
         current_library_logging = self.config_entry.data.get(
             CONF_ENABLE_LIBRARY_LOGGING, False
+        )
+        current_drop_unassigned = self.config_entry.data.get(
+            CONF_DROP_UNASSIGNED_MEASUREMENTS, False
         )
 
         return self.async_show_form(
@@ -1533,6 +1540,10 @@ class ScaleOptionsFlow(OptionsFlow):
                     vol.Required(
                         CONF_ENABLE_LIBRARY_LOGGING,
                         default=current_library_logging,
+                    ): bool,
+                    vol.Required(
+                        CONF_DROP_UNASSIGNED_MEASUREMENTS,
+                        default=current_drop_unassigned,
                     ): bool,
                 }
             ),

--- a/custom_components/etekcity_fitness_scale_ble/const.py
+++ b/custom_components/etekcity_fitness_scale_ble/const.py
@@ -60,6 +60,7 @@ CONF_MAX_HISTORY_SIZE = "max_history_size"
 
 # Advanced settings
 CONF_ENABLE_LIBRARY_LOGGING = "enable_library_logging"
+CONF_DROP_UNASSIGNED_MEASUREMENTS = "drop_unassigned_measurements"
 
 # Adaptive tolerance - base calculation (hybrid percentage with bounds)
 DEFAULT_TOLERANCE_PERCENTAGE = 0.04  # 4% of user's weight

--- a/custom_components/etekcity_fitness_scale_ble/coordinator.py
+++ b/custom_components/etekcity_fitness_scale_ble/coordinator.py
@@ -51,6 +51,7 @@ from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import MassConverter
 
 from .const import (
+    CONF_DROP_UNASSIGNED_MEASUREMENTS,
     CONF_ENABLE_LIBRARY_LOGGING,
     CONF_HISTORY_RETENTION_DAYS,
     CONF_MAX_HISTORY_SIZE,
@@ -1095,6 +1096,21 @@ class ScaleDataUpdateCoordinator:
 
         return entry.data.get(CONF_ENABLE_LIBRARY_LOGGING, False)
 
+    def _is_drop_unassigned_enabled(self) -> bool:
+        """Check if dropping unassigned measurements is enabled in config entry.
+
+        Returns:
+            True if unassigned measurements should be dropped, False otherwise (default).
+        """
+        if not self._config_entry_id:
+            return False
+
+        entry = self._hass.config_entries.async_get_entry(self._config_entry_id)
+        if not entry:
+            return False
+
+        return entry.data.get(CONF_DROP_UNASSIGNED_MEASUREMENTS, False)
+
     def _configure_library_logger(self) -> logging.Logger | None:
         """Configure the etekcity_esf551_ble logger based on the advanced setting.
 
@@ -1828,9 +1844,20 @@ class ScaleDataUpdateCoordinator:
         # This ensures consistent timestamps across all code paths (auto-assign, detection, pending)
         measurement_timestamp = datetime.now().isoformat()
 
-        # Smart detection logic: Single user auto-assign (skip detection)
+        # Smart detection logic: Single user auto-assign skipping detection by
+        # default. Perform detection if 'drop assigned' is set to properly
+        # handle unassigned measurements
         if len(self._user_profiles) == 1:
             user_id = self._user_profiles[0].get(CONF_USER_ID)
+            if self._is_drop_unassigned_enabled():
+                candidates = self._person_detector.detect_person(weight_kg, self._user_profiles)
+                if not candidates:
+                    _LOGGER.info(
+                        "Dropping unassigned measurement (weight: %.2f kg) — outside range of sole user %s",
+                        weight_kg,
+                        user_id,
+                    )
+                    return
             _LOGGER.debug(
                 "Single user detected, auto-assigning measurement to user %s (weight: %.2f kg)",
                 user_id,
@@ -1848,7 +1875,14 @@ class ScaleDataUpdateCoordinator:
 
         # Fallback: If no candidates found, include all users
         # This prevents data loss when weight is out of tolerance for all users
+        # Skip if we're dropping all unassigned measurements
         if not candidates:
+            if self._is_drop_unassigned_enabled():
+                _LOGGER.info(
+                    "Dropping unassigned measurement (weight: %.2f kg) — outside range of all users",
+                    weight_kg,
+                )
+                return
             _LOGGER.debug(
                 "No candidates detected for weight %.2f kg, falling back to all users",
                 weight_kg,

--- a/custom_components/etekcity_fitness_scale_ble/strings.json
+++ b/custom_components/etekcity_fitness_scale_ble/strings.json
@@ -189,12 +189,14 @@
         "data": {
           "history_retention_days": "History Retention (days)",
           "max_history_size": "Max History Size (measurements)",
-          "enable_library_logging": "Enable Library Logging"
+          "enable_library_logging": "Enable Library Logging",
+          "drop_unassigned_measurements": "Drop Unassigned Measurements"
         },
         "data_description": {
           "history_retention_days": "How many days to keep weight measurements. Older measurements will be automatically removed. Range: 1-365 days.",
           "max_history_size": "Maximum number of measurements to store per user. When exceeded, oldest measurements are removed. Range: 10-1000 measurements.",
-          "enable_library_logging": "When enabled, logs from the underlying etekcity_esf551_ble library will be included in the integration's logs. Useful for troubleshooting BLE communication issues."
+          "enable_library_logging": "When enabled, logs from the underlying etekcity_esf551_ble library will be included in the integration's logs. Useful for troubleshooting BLE communication issues.",
+          "drop_unassigned_measurements": "When enabled, any measurement whose weight falls outside the range of every configured user is discarded instead of being assigned. Useful for ignoring guests, pets, or stray readings. Disabled by default."
         }
       }
     },

--- a/custom_components/etekcity_fitness_scale_ble/translations/en.json
+++ b/custom_components/etekcity_fitness_scale_ble/translations/en.json
@@ -189,12 +189,14 @@
         "data": {
           "history_retention_days": "History Retention (days)",
           "max_history_size": "Max History Size (measurements)",
-          "enable_library_logging": "Enable Library Logging"
+          "enable_library_logging": "Enable Library Logging",
+          "drop_unassigned_measurements": "Drop Unassigned Measurements"
         },
         "data_description": {
           "history_retention_days": "How many days to keep weight measurements. Older measurements will be automatically removed. Range: 1-365 days.",
           "max_history_size": "Maximum number of measurements to store per user. When exceeded, oldest measurements are removed. Range: 10-1000 measurements.",
-          "enable_library_logging": "When enabled, logs from the underlying etekcity_esf551_ble library will be included in the integration's logs. Useful for troubleshooting BLE communication issues."
+          "enable_library_logging": "When enabled, logs from the underlying etekcity_esf551_ble library will be included in the integration's logs. Useful for troubleshooting BLE communication issues.",
+          "drop_unassigned_measurements": "When enabled, any measurement whose weight falls outside the range of every configured user is discarded instead of being assigned. Useful for ignoring guests, pets, or stray readings. Disabled by default."
         }
       }
     },


### PR DESCRIPTION
Adds a new boolean option in the Advanced Settings options flow that silently discards any measurement whose weight falls outside the tolerance range of every configured user profile instead of falling back to an ambiguous notification.

This is useful for ad-hoc measurements and for households where a scale is occasionally used by guests, pets, or anything else that should never be recorded.

This works for both the single user and the multi-user flow. If there is only a single user, then only weights within the tolerance range will be assigned; other are dropped.