### PR TITLE
Add EFS-A591S-KUS (Apex HR) scale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This custom integration allows you to connect your Etekcity Bluetooth Low Energy
 
 ## Features
 
-- **Supported models:** ESF-551 (full features: weight, impedance, body composition), FIT-8S (weight, impedance, body composition; experimental), and ESF-24 (weight and display unit; experimental)
+- **Supported models:** ESF-551 (full features: weight, impedance, body composition), FIT-8S (weight, impedance, body composition; experimental), ESF-24 (weight and display unit; experimental), and EFS-A591S-KUS / Apex HR (weight, impedance, body composition, heart rate; experimental)
 - Automatic discovery of Etekcity BLE fitness scales
 - Intelligent multi-user support:
     - Automatically detects which person is using the scale based on their weight history.
     - Uses an adaptive tolerance system that adjusts to each user's weight fluctuations over time.
     - Supports linking users to Home Assistant Person entities to exclude users who are `not_home`.
 - Real-time weight and impedance measurements
-- Optional body composition metrics (ESF-551 and FIT-8S) including:
+- Optional body composition metrics (ESF-551, FIT-8S, and EFS-A591S) including:
     - Body Mass Index (BMI)
     - Body Fat Percentage
     - Fat Free Weight
@@ -26,6 +26,7 @@ This custom integration allows you to connect your Etekcity Bluetooth Low Energy
     - Bone Mass
     - Protein Percentage
     - Metabolic Age
+- Heart rate in beats per minute (EFS-A591S only)
 - Customizable display units (kg, lb)
 - Direct Bluetooth communication (no internet or VeSync app required)
 
@@ -33,8 +34,8 @@ This custom integration allows you to connect your Etekcity Bluetooth Low Energy
 
 - This integration does not currently support "Athlete Mode". All body composition measurements are based on standard calculations.
 - **ESF-24** scales receive weight sensors and display unit settings only; body composition is not currently supported for this model.
-- **FIT-8S** is advertisement-based: the display unit you select affects the Home Assistant display only and is *not* sent to the scale. For ESF-551 and ESF-24 the selected unit is pushed to the scale's screen; Home Assistant cannot change what a FIT-8S shows (use the button on the scale for that), so for FIT-8S the two are independent.
-- This integration uses the [etekcity_esf551_ble](https://github.com/ronnnnnnnnnnnnn/etekcity_esf551_ble) Python library (v0.5.0+) for scale communication.
+- **FIT-8S** is advertisement-based: the display unit you select affects the Home Assistant display only and is *not* sent to the scale. For ESF-551, ESF-24, and EFS-A591S the selected unit is pushed to the scale's screen; Home Assistant cannot change what a FIT-8S shows (use the button on the scale for that), so for FIT-8S the two are independent.
+- This integration uses the [etekcity_esf551_ble](https://github.com/ronnnnnnnnnnnnn/etekcity_esf551_ble) Python library (v0.6.0+) for scale communication.
 
 ## Installation
 
@@ -61,8 +62,8 @@ This custom integration allows you to connect your Etekcity Bluetooth Low Energy
 3. Search for "Etekcity Fitness Scale BLE" and select it.
 4. Follow the configuration steps:
     - Choose your preferred unit system (Metric or Imperial)
-    - For **ESF-551** and **FIT-8S**: optionally enable body composition metrics
-    - If body composition is enabled (ESF-551 / FIT-8S):
+    - For **ESF-551**, **FIT-8S**, and **EFS-A591S**: optionally enable body composition metrics
+    - If body composition is enabled (ESF-551 / FIT-8S / EFS-A591S):
         - Select your sex
         - Enter your date of birth
         - Enter your height
@@ -81,7 +82,7 @@ When adding or editing user profiles (**Settings → Devices & Services → Etek
   - When enabled, you'll receive a mobile notification with tap-to-assign buttons directly on your phone
   - Each candidate user gets a personalized notification with "This is me" and "Not me" buttons
 
-- **Enable body composition metrics (ESF-551 / FIT-8S only):** Calculate additional health metrics (BMI, body fat %, etc.) based on impedance measurements. Requires sex, date of birth, and height. Not available for ESF-24.
+- **Enable body composition metrics (ESF-551 / FIT-8S / EFS-A591S only):** Calculate additional health metrics (BMI, body fat %, etc.) based on impedance measurements. Requires sex, date of birth, and height. Not available for ESF-24.
 
 ## Multi-User Support
 
@@ -173,6 +174,7 @@ This integration supports the following Etekcity scale models:
 | [ESF-551 Smart Fitness Scale](https://etekcity.com/products/smart-fitness-scale-esf551) | Fully supported | Weight, impedance, body composition, display unit |
 | [FIT-8S Smart Fitness Scale](https://etekcity.com/products/smart-fitness-scale-fit-8s) | Experimental | Weight, impedance, body composition |
 | [ESF-24 Smart Fitness Scale](https://etekcity.com/products/smart-fitness-scale-esf24) | Experimental | Weight, display unit |
+| EFS-A591S-KUS (Apex HR) Smart Fitness Scale | Experimental | Weight, impedance, body composition, heart rate, display unit |
 
 *As an Amazon Associate I earn from qualifying purchases.*
 

--- a/custom_components/etekcity_fitness_scale_ble/config_flow.py
+++ b/custom_components/etekcity_fitness_scale_ble/config_flow.py
@@ -52,7 +52,11 @@ from .const import (
     CONF_USER_PROFILES,
     CONF_WEIGHT_HISTORY,
     BLUETOOTH_MATCHERS,
+    BODY_METRICS_MODELS,
     DOMAIN,
+    EFSA591S_MODEL_CODES,
+    EFSA591S_MODEL_OFFSET,
+    ETEKCITY_MANUFACTURER_ID,
     HISTORY_RETENTION_DAYS,
     MAX_HISTORY_SIZE,
     ScaleModel,
@@ -82,8 +86,23 @@ def _device_matches_matcher(
     return fnmatch.fnmatch(name.lower(), local_name_pattern.lower())
 
 
+def _is_efsa591s(discovery_info: BluetoothServiceInfo) -> bool:
+    """Return True if the manufacturer data carries an EFS-A591S model code."""
+    mfr = discovery_info.manufacturer_data.get(ETEKCITY_MANUFACTURER_ID)
+    return (
+        mfr is not None
+        and len(mfr) > EFSA591S_MODEL_OFFSET
+        and mfr[EFSA591S_MODEL_OFFSET] in EFSA591S_MODEL_CODES
+    )
+
+
 def _device_matches_any_matcher(discovery_info: BluetoothServiceInfo) -> bool:
     """Return True if discovery_info matches any of our Bluetooth matchers (manifest)."""
+    # The EFS-A591S can't be matched by name (absent in passive scans, the
+    # ESF-551's name in active scans), so identify it by the manufacturer-data
+    # model byte before falling through to the name matchers.
+    if _is_efsa591s(discovery_info):
+        return True
     return any(
         _device_matches_matcher(discovery_info, mfr_id, name_pattern)
         for _, mfr_id, name_pattern in BLUETOOTH_MATCHERS
@@ -95,6 +114,16 @@ def detect_scale_model(discovery_info: BluetoothServiceInfo) -> ScaleModel:
 
     Uses BLUETOOTH_MATCHERS (aligned with manifest.json); first match wins.
     """
+    # The EFS-A591S check runs ABOVE the BLUETOOTH_MATCHERS loop on purpose: it
+    # shares the ESF-551's manufacturer ID, and its name is unreliable (absent in
+    # passive scans, the ESF-551's in active scans), so the matchers cannot
+    # distinguish the two and would misidentify or miss it. It is identifiable
+    # only by the model byte in the manufacturer data, which those matchers do
+    # not inspect.
+    if _is_efsa591s(discovery_info):
+        _LOGGER.debug("Detected EFS-A591S scale: %s", discovery_info.name)
+        return ScaleModel.EFSA591S
+
     for scale_model, manufacturer_id, local_name_pattern in BLUETOOTH_MATCHERS:
         if _device_matches_matcher(discovery_info, manufacturer_id, local_name_pattern):
             _LOGGER.debug(
@@ -480,7 +509,7 @@ class ScaleConfigFlow(ConfigFlow, domain=DOMAIN):
                         available_mobile_services
                     )
 
-                if scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S):
+                if scale_model in BODY_METRICS_MODELS:
                     schema[vol.Required(CONF_BODY_METRICS_ENABLED, default=False)] = (
                         cv.boolean
                     )
@@ -494,7 +523,7 @@ class ScaleConfigFlow(ConfigFlow, domain=DOMAIN):
             # Check if body metrics is enabled (ESF24 does not support body metrics)
             body_metrics_enabled = (
                 user_input.get(CONF_BODY_METRICS_ENABLED, False)
-                if scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S)
+                if scale_model in BODY_METRICS_MODELS
                 else False
             )
             if body_metrics_enabled:
@@ -548,7 +577,7 @@ class ScaleConfigFlow(ConfigFlow, domain=DOMAIN):
                 available_mobile_services
             )
 
-        if scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S):
+        if scale_model in BODY_METRICS_MODELS:
             schema[vol.Required(CONF_BODY_METRICS_ENABLED, default=False)] = cv.boolean
 
         return self.async_show_form(
@@ -849,7 +878,7 @@ class ScaleOptionsFlow(OptionsFlow):
                         available_mobile_services
                     )
 
-                if self.scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S):
+                if self.scale_model in BODY_METRICS_MODELS:
                     schema[vol.Required(CONF_BODY_METRICS_ENABLED, default=False)] = (
                         cv.boolean
                     )
@@ -863,7 +892,7 @@ class ScaleOptionsFlow(OptionsFlow):
             # Check if body metrics is enabled (ESF24 does not support body metrics)
             body_metrics_enabled = (
                 user_input.get(CONF_BODY_METRICS_ENABLED, False)
-                if self.scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S)
+                if self.scale_model in BODY_METRICS_MODELS
                 else False
             )
             if body_metrics_enabled:
@@ -927,7 +956,7 @@ class ScaleOptionsFlow(OptionsFlow):
                 available_mobile_services
             )
 
-        if self.scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S):
+        if self.scale_model in BODY_METRICS_MODELS:
             schema[vol.Required(CONF_BODY_METRICS_ENABLED, default=False)] = cv.boolean
 
         return self.async_show_form(
@@ -1160,7 +1189,7 @@ class ScaleOptionsFlow(OptionsFlow):
                     ] = cv.multi_select(available_mobile_services)
 
                 # Add body metrics toggle last (ESF24 does not support body metrics)
-                if self.scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S):
+                if self.scale_model in BODY_METRICS_MODELS:
                     schema[
                         vol.Required(
                             CONF_BODY_METRICS_ENABLED,
@@ -1177,7 +1206,7 @@ class ScaleOptionsFlow(OptionsFlow):
             # Check if body metrics is being enabled/disabled (ESF24: always False)
             body_metrics_enabled = (
                 user_input.get(CONF_BODY_METRICS_ENABLED, False)
-                if self.scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S)
+                if self.scale_model in BODY_METRICS_MODELS
                 else False
             )
             currently_enabled = current_user.get(CONF_BODY_METRICS_ENABLED, False)
@@ -1273,7 +1302,7 @@ class ScaleOptionsFlow(OptionsFlow):
             ] = cv.multi_select(available_mobile_services)
 
         # Add body metrics toggle last (ESF24 does not support body metrics)
-        if self.scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S):
+        if self.scale_model in BODY_METRICS_MODELS:
             schema[
                 vol.Required(
                     CONF_BODY_METRICS_ENABLED,

--- a/custom_components/etekcity_fitness_scale_ble/const.py
+++ b/custom_components/etekcity_fitness_scale_ble/const.py
@@ -21,18 +21,40 @@ class ScaleModel(StrEnum):
     ESF551 = "ESF-551"
     ESF24 = "ESF-24"
     FIT8S = "FIT-8S"
+    EFSA591S = "EFS-A591S"
 
 
 # Bluetooth matchers: single source of truth aligned with manifest.json "bluetooth" entries.
+ETEKCITY_MANUFACTURER_ID = 1744
+
 # Order matters: first match wins for model detection. Each entry is (ScaleModel, manufacturer_id|None, local_name_pattern).
 # local_name_pattern uses fnmatch syntax (e.g. "*" for wildcard).
 BLUETOOTH_MATCHERS: list[tuple[ScaleModel, int | None, str]] = [
     (ScaleModel.ESF24, None, "QN-Scale1"),
     (ScaleModel.ESF24, None, "04:AC:44:*"),
-    (ScaleModel.ESF551, 1744, "Etekcity *Fitness *Scale*"),
-    (ScaleModel.ESF551, 1744, "D0:4D:00:*"),
-    (ScaleModel.FIT8S, 1744, "A9:89:5D:*"),
+    (ScaleModel.ESF551, ETEKCITY_MANUFACTURER_ID, "Etekcity *Fitness *Scale*"),
+    (ScaleModel.ESF551, ETEKCITY_MANUFACTURER_ID, "D0:4D:00:*"),
+    (ScaleModel.FIT8S, ETEKCITY_MANUFACTURER_ID, "A9:89:5D:*"),
 ]
+
+# The EFS-A591S can't be told apart from the ESF-551 by its advertisement: both
+# use ETEKCITY_MANUFACTURER_ID (1744), and the EFS-A591S sends its name
+# ("Etekcity Smart Fitness Scale") only in the scan response. Passive scans
+# therefore see no name, and active scans see a name that matches the ESF-551
+# matcher ("Etekcity *Fitness *Scale*"), so neither can tell the two apart. The
+# EFS-A591S is identified instead by a model-code byte in the primary
+# advertisement's manufacturer data at EFSA591S_MODEL_OFFSET.
+# Known EFS-A591S model codes: EFSA591SUs=3, KUSTUs=5, V5Us=127, V5KUSTUs=134.
+# (The ESF-551 is model 9729, so it never collides with this set.)
+EFSA591S_MODEL_OFFSET = 8
+EFSA591S_MODEL_CODES = frozenset({3, 5, 127, 134})
+
+# Models that measure impedance and therefore support body-metrics calculation
+# (weight + impedance + user profile). The ESF-24 is weight-only and excluded.
+BODY_METRICS_MODELS = frozenset({ScaleModel.ESF551, ScaleModel.FIT8S, ScaleModel.EFSA591S})
+
+# Models that also report heart rate (bpm) on the final measurement.
+HEART_RATE_MODELS = frozenset({ScaleModel.EFSA591S})
 
 # Multi-user constants (v2+)
 CONF_SCALE_DISPLAY_UNIT = "scale_display_unit"

--- a/custom_components/etekcity_fitness_scale_ble/coordinator.py
+++ b/custom_components/etekcity_fitness_scale_ble/coordinator.py
@@ -1992,7 +1992,7 @@ class ScaleDataUpdateCoordinator:
         # Calculate body metrics if enabled for this user (newest measurement scenario)
         if user_profile.get("body_metrics_enabled", False):
             try:
-                from etekcity_esf551_ble.esf551.body_metrics import (
+                from etekcity_esf551_ble.body_metrics import (
                     BodyMetrics,
                     Sex,
                     _as_dictionary,
@@ -2527,7 +2527,7 @@ class ScaleDataUpdateCoordinator:
         # Calculate body metrics if enabled for this user
         if user_profile.get("body_metrics_enabled", False):
             try:
-                from etekcity_esf551_ble.esf551.body_metrics import (
+                from etekcity_esf551_ble.body_metrics import (
                     BodyMetrics,
                     Sex,
                     _as_dictionary,

--- a/custom_components/etekcity_fitness_scale_ble/coordinator.py
+++ b/custom_components/etekcity_fitness_scale_ble/coordinator.py
@@ -37,8 +37,9 @@ from etekcity_esf551_ble import (
 )
 
 try:
-    from etekcity_esf551_ble import ESF24Scale, ESF551Scale, FIT8SScale
+    from etekcity_esf551_ble import EFSA591SScale, ESF24Scale, ESF551Scale, FIT8SScale
 except ImportError:
+    EFSA591SScale = None  # type: ignore[misc, assignment]
     ESF24Scale = None  # type: ignore[misc, assignment]
     ESF551Scale = None  # type: ignore[misc, assignment]
     FIT8SScale = None  # type: ignore[misc, assignment]
@@ -1383,6 +1384,16 @@ class ScaleDataUpdateCoordinator:
                         bleak_scanner_backend=scanner,
                         logger=library_logger,
                     )
+                elif self._scale_model == ScaleModel.EFSA591S and EFSA591SScale is not None:
+                    _LOGGER.debug("Initializing new EFSA591SScale client")
+                    self._client = EFSA591SScale(
+                        self.address,
+                        self.update_listeners,
+                        self._display_unit,
+                        scanning_mode=BluetoothScanningMode.PASSIVE,
+                        bleak_scanner_backend=scanner,
+                        logger=library_logger,
+                    )
                 else:
                     # Fallback: use generic client (e.g. library < 0.4 or unknown model)
                     _LOGGER.debug(
@@ -1678,13 +1689,15 @@ class ScaleDataUpdateCoordinator:
             data: The scale data containing all measurements.
 
         Returns:
-            Dictionary with only raw measurements (weight, impedance).
+            Dictionary with only raw measurements (weight, impedance, heart_rate).
         """
         raw_measurements = {}
         if "weight" in data.measurements:
             raw_measurements["weight"] = data.measurements["weight"]
         if "impedance" in data.measurements:
             raw_measurements["impedance"] = data.measurements["impedance"]
+        if "heart_rate" in data.measurements:
+            raw_measurements["heart_rate"] = data.measurements["heart_rate"]
         return raw_measurements
 
     def _validate_measurement(

--- a/custom_components/etekcity_fitness_scale_ble/manifest.json
+++ b/custom_components/etekcity_fitness_scale_ble/manifest.json
@@ -31,7 +31,8 @@
     },
     {
       "connectable": true,
-      "manufacturer_id": 1744
+      "manufacturer_id": 1744,
+      "local_name": "CF:EA:01:*"
     }
   ],
   "codeowners": [

--- a/custom_components/etekcity_fitness_scale_ble/manifest.json
+++ b/custom_components/etekcity_fitness_scale_ble/manifest.json
@@ -28,6 +28,10 @@
       "connectable": false,
       "manufacturer_id": 1744,
       "local_name": "A9:89:5D:*"
+    },
+    {
+      "connectable": true,
+      "manufacturer_id": 1744
     }
   ],
   "codeowners": [
@@ -42,7 +46,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ronnnnnnnnnnnnn/etekcity_fitness_scale_ble/issues",
   "requirements": [
-    "etekcity_esf551_ble==0.5.0"
+    "etekcity_esf551_ble==0.6.0"
   ],
   "version": "0.5.1"
 }

--- a/custom_components/etekcity_fitness_scale_ble/sensor.py
+++ b/custom_components/etekcity_fitness_scale_ble/sensor.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Self
 
-from etekcity_esf551_ble import IMPEDANCE_KEY, WEIGHT_KEY, WeightUnit
+from etekcity_esf551_ble import HEART_RATE_KEY, IMPEDANCE_KEY, WEIGHT_KEY, WeightUnit
 
 from homeassistant import config_entries
 from homeassistant.components.sensor import (
@@ -28,6 +28,7 @@ from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceIn
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
+    BODY_METRICS_MODELS,
     CONF_BODY_METRICS_ENABLED,
     CONF_CALC_BODY_METRICS,
     CONF_SCALE_DISPLAY_UNIT,
@@ -36,6 +37,7 @@ from .const import (
     CONF_USER_NAME,
     CONF_USER_PROFILES,
     DOMAIN,
+    HEART_RATE_MODELS,
     ScaleModel,
     get_sensor_unique_id,
 )
@@ -220,7 +222,27 @@ async def async_setup_entry(
                 ),
             ]
 
-            if scale_model in (ScaleModel.ESF551, ScaleModel.FIT8S):
+            # Heart rate is a direct measurement (not a computed body metric), so
+            # it is added independently of body_metrics_enabled - only the
+            # EFS-A591S reports it.
+            if scale_model in HEART_RATE_MODELS:
+                user_entities.append(
+                    ScaleUserSensor(
+                        entry.title,
+                        address,
+                        coordinator,
+                        SensorEntityDescription(
+                            key=HEART_RATE_KEY,
+                            icon="mdi:heart-pulse",
+                            native_unit_of_measurement="bpm",
+                            state_class=SensorStateClass.MEASUREMENT,
+                        ),
+                        user_id=user_id,
+                        user_name=user_name,
+                    ),
+                )
+
+            if scale_model in BODY_METRICS_MODELS:
                 user_entities.append(
                     ScaleUserSensor(
                         entry.title,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-etekcity_esf551_ble==0.5.0
+etekcity_esf551_ble==0.6.0
 ruff==0.6.2


### PR DESCRIPTION
Adds support for the EFS-A591S-KUS, backed by `etekcity_esf551_ble==0.6.0` (now on PyPI). It uses your reorganized 0.6.0 tree; `EFSA591SScale` is imported the same way as the other models.

## What it adds
- Model detection for the EFS-A591S (`const`, `config_flow`).
- Weight, impedance, and per-user body composition (the model is in `BODY_METRICS_MODELS`).
- Heart rate: a per-user `bpm` sensor gated by `HEART_RATE_MODELS`. The scale reports it in the result frame; 0 means not measured.
- Display unit: the existing kg/lb option is passed to `EFSA591SScale`, which sends it to the scale on connect. No new UI; it reuses the `CONF_SCALE_DISPLAY_UNIT` path.
- README: the model is listed with the others and marked Experimental.

## Discovery
The EFS-A591S advertises manufacturer id 1744 and no device name. It is matched by a `connectable: true` entry scoped to the `CF:EA:01:*` address prefix, in the style of the existing prefix matchers, relying on HA's address-as-name fallback for nameless devices. Confirmed on hardware: the auto-discovery card was generated after removing the existing scale from Home Assistant. The prefix covers my unit; other units may need one added later. This model needs `connectable: true`, unlike the FIT-8S: it does not put weight in its advertisements, it requires a GATT connection and an encrypted handshake, so both discovery and reading go through the connectable path. `detect_scale_model` identifies it by the manufacturer-data model byte, ahead of the name matchers, since it has no name to match.

## Hardware validation
Tested on a physical EFS-A591S through an ESPHome Bluetooth proxy on 0.6.0. Weight, impedance, heart rate, and all body-composition sensors populate. Body composition was compared against the VeSync app for the same weigh-in; BMI, body fat, body water, skeletal muscle, visceral fat, subcutaneous fat, muscle mass, and bone mass matched within rounding. Switching kg/lb in the options flow changes the scale's own screen on the next connect.

## The 0.6.0 body-metrics fix
0.6.0 turned `esf551/body_metrics.py` into a deprecation shim that re-exports only `BodyMetrics` and `Sex`; the private helpers `_as_dictionary` and `_calc_age` moved to the top-level `etekcity_esf551_ble.body_metrics`. The coordinator imported all four from the old path, which raised `ImportError` inside the body-metrics `try` block and silently disabled every computed body-composition sensor for all models (weight, impedance, and heart rate were unaffected). Both imports now point at the top-level module.

The manifest version is set to 0.5.1 for my own HACS testing; set it wherever fits your release.
