### PR TITLE
Fix weight history corruption when the display unit changes

### DIFF
--- a/custom_components/etekcity_fitness_scale_ble/sensor.py
+++ b/custom_components/etekcity_fitness_scale_ble/sensor.py
@@ -14,7 +14,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorExtraStoredData,
     SensorStateClass,
-    async_update_suggested_units,
 )
 from homeassistant.const import (
     CONF_UNIT_SYSTEM,
@@ -285,20 +284,20 @@ async def async_setup_entry(
             ]
         )
 
-    # Update suggested units for weight sensors
-    def _update_unit(sensor: ScaleSensor, unit: str) -> ScaleSensor:
-        if getattr(sensor, "_attr_device_class", None) == SensorDeviceClass.WEIGHT:
-            sensor._attr_suggested_unit_of_measurement = unit
-        return sensor
-
-    # Set display unit on coordinator
+    # Tell the coordinator the configured display unit. This drives the unit the
+    # scale itself shows (pushed to the scale) and the unit used in notifications.
+    # It deliberately does NOT set the Home Assistant sensor unit: the weight
+    # sensors report native kilograms with device_class=WEIGHT, so HA converts them
+    # to the user's preferred unit for display (unit system or per-entity override).
+    # Flipping the sensor unit here (via suggested_unit_of_measurement /
+    # async_update_suggested_units) rewrote the stored native value into the display
+    # unit and corrupted history on every switch; keeping native as kg lets HA
+    # convert cleanly across the whole history.
     coordinator.set_display_unit(
         WeightUnit.KG if display_unit == UnitOfMass.KILOGRAMS else WeightUnit.LB
     )
 
-    entities = [_update_unit(sensor, display_unit) for sensor in entities]
     async_add_entities(entities)
-    async_update_suggested_units(hass)
 
     # Start the coordinator AFTER entities are added
     # This ensures listeners are registered before BLE scanning begins
@@ -486,9 +485,11 @@ class ScaleWeightSensor(ScaleSensor):
         if last_state := await self.async_get_last_sensor_data():
             _LOGGER.debug("Restoring previous state for sensor: %s", self.entity_id)
             self._attr_native_value = last_state.native_value
-            self._attr_native_unit_of_measurement = (
-                last_state.native_unit_of_measurement
-            )
+            # Do not restore native_unit_of_measurement: it must stay kg (the
+            # entity description). Restoring it let the native unit drift to the
+            # display unit, after which HA stopped converting and showed the kg
+            # value under the lb label. With native pinned to kg, HA converts the
+            # value to whatever display unit is selected.
 
             address = self._id
             device_registry = dr.async_get(self.hass)
@@ -668,9 +669,11 @@ class ScaleUserWeightSensor(ScaleUserSensor):
         if last_state := await self.async_get_last_sensor_data():
             _LOGGER.debug("Restoring previous state for sensor: %s", self.entity_id)
             self._attr_native_value = last_state.native_value
-            self._attr_native_unit_of_measurement = (
-                last_state.native_unit_of_measurement
-            )
+            # Do not restore native_unit_of_measurement: it must stay kg (the
+            # entity description). Restoring it let the native unit drift to the
+            # display unit, after which HA stopped converting and showed the kg
+            # value under the lb label. With native pinned to kg, HA converts the
+            # value to whatever display unit is selected.
 
             address = self._id
             device_registry = dr.async_get(self.hass)


### PR DESCRIPTION
Switching the display unit corrupted weight history. A reading recorded under one unit showed up under the other unit's label without being converted: a 220.53 lb reading displayed as "220.53 kg" after switching to kg, and the history graph ended up with mixed units.

## Root cause
The integration flips each weight sensor's unit on every load, via `suggested_unit_of_measurement` in `_update_unit` plus `async_update_suggested_units(hass)`. That machinery rewrites the stored **native** value into the display unit (100.03 kg becomes 220.53 lb) and changes `native_unit_of_measurement`. HA's recorder stores the native value, so history ends up written in whatever unit was active at record time, and a later switch relabels those old rows instead of converting them.

## Fix
HA's recorder stores the native value, and `device_class=WEIGHT` converts it to the user's unit for display consistently across history. So keep the weight sensors native in kilograms and never change their unit:

- Remove `_update_unit` / `suggested_unit_of_measurement` and the `async_update_suggested_units` call (and its import).
- Stop restoring `native_unit_of_measurement` in the weight sensors; it stays kg from the entity description.

HA now converts the whole history to the selected unit instead of relabeling it. Affects every weight-typed sensor (weight, fat-free weight, muscle mass, bone mass).

## Behavior change
HA's display unit for the weight sensors now follows the HA unit system or a per-entity unit override, instead of `CONF_SCALE_DISPLAY_UNIT`. That option still drives the scale's own screen (the unit pushed to the scale) and the unit used in notification text. Users change the HA display unit through the entity's Unit of Measurement setting, which converts cleanly. If you'd rather the option keep driving the HA display too, say so and I'll look at a conversion-safe way to do it, but letting HA own the display is what keeps history consistent.

## Testing
Tested on hardware (EFS-A591S via an ESPHome proxy): switching the weight entity's unit reprices existing readings by about 2.2x instead of relabeling them.

One caveat: rows written before this fix were already stored in the wrong unit and can't be retro-converted; new readings are clean.
