### PR TITLE
Allow 0 = unlimited for history retention and max size

### DIFF
--- a/custom_components/etekcity_fitness_scale_ble/config_flow.py
+++ b/custom_components/etekcity_fitness_scale_ble/config_flow.py
@@ -1602,14 +1602,16 @@ class ScaleOptionsFlow(OptionsFlow):
                         default=self.history_retention_days,
                     ): vol.All(
                         vol.Coerce(int),
-                        vol.Range(min=1, max=365),
+                        # 0 = never delete by age (keep history indefinitely)
+                        vol.Range(min=0, max=365),
                     ),
                     vol.Required(
                         CONF_MAX_HISTORY_SIZE,
                         default=self.max_history_size,
                     ): vol.All(
                         vol.Coerce(int),
-                        vol.Range(min=10, max=1000),
+                        # 0 = unlimited (no cap on number of measurements)
+                        vol.Range(min=0, max=1000),
                     ),
                     vol.Required(
                         CONF_ENABLE_LIBRARY_LOGGING,

--- a/custom_components/etekcity_fitness_scale_ble/coordinator.py
+++ b/custom_components/etekcity_fitness_scale_ble/coordinator.py
@@ -1133,31 +1133,34 @@ class ScaleDataUpdateCoordinator:
         retention_days = self._get_history_retention_days()
         max_size = self._get_max_history_size()
 
-        # Remove measurements older than retention window
-        # Handle invalid timestamps gracefully to prevent crashes from corrupted data
-        cutoff_time = datetime.now() - timedelta(days=retention_days)
-        valid_measurements = []
-        for m in history:
-            timestamp_str = m.get("timestamp")
-            if not timestamp_str:
-                _LOGGER.warning("Measurement missing timestamp, removing: %s", m)
-                continue
-            try:
-                parsed_timestamp = datetime.fromisoformat(timestamp_str)
-                if parsed_timestamp >= cutoff_time:
-                    valid_measurements.append(m)
-            except (ValueError, TypeError) as ex:
-                _LOGGER.warning(
-                    "Invalid timestamp format '%s' in measurement, removing: %s",
-                    timestamp_str,
-                    ex,
-                )
-                continue
+        # retention_days == 0 means "never delete by age" - skip the age window
+        # entirely (max_size still applies as a hard cap below).
+        if retention_days > 0:
+            # Remove measurements older than retention window
+            # Handle invalid timestamps gracefully to prevent crashes from corrupted data
+            cutoff_time = datetime.now() - timedelta(days=retention_days)
+            valid_measurements = []
+            for m in history:
+                timestamp_str = m.get("timestamp")
+                if not timestamp_str:
+                    _LOGGER.warning("Measurement missing timestamp, removing: %s", m)
+                    continue
+                try:
+                    parsed_timestamp = datetime.fromisoformat(timestamp_str)
+                    if parsed_timestamp >= cutoff_time:
+                        valid_measurements.append(m)
+                except (ValueError, TypeError) as ex:
+                    _LOGGER.warning(
+                        "Invalid timestamp format '%s' in measurement, removing: %s",
+                        timestamp_str,
+                        ex,
+                    )
+                    continue
 
-        history[:] = valid_measurements
+            history[:] = valid_measurements
 
-        # Enforce max size (keep newest)
-        if len(history) > max_size:
+        # Enforce max size (keep newest); max_size == 0 means unlimited
+        if max_size > 0 and len(history) > max_size:
             history[:] = history[-max_size:]
 
     def _log_user_history(self, user_id: str, context: str) -> None:

--- a/custom_components/etekcity_fitness_scale_ble/strings.json
+++ b/custom_components/etekcity_fitness_scale_ble/strings.json
@@ -201,8 +201,8 @@
           "enable_library_logging": "Enable Library Logging"
         },
         "data_description": {
-          "history_retention_days": "How many days to keep weight measurements. Older measurements will be automatically removed. Range: 1-365 days.",
-          "max_history_size": "Maximum number of measurements to store per user. When exceeded, oldest measurements are removed. Range: 10-1000 measurements.",
+          "history_retention_days": "How many days to keep weight measurements. Older measurements will be automatically removed. Range: 0-365 days (0 = never delete by age).",
+          "max_history_size": "Maximum number of measurements to store per user. When exceeded, oldest measurements are removed. Range: 0-1000 measurements (0 = unlimited).",
           "enable_library_logging": "When enabled, logs from the underlying etekcity_esf551_ble library will be included in the integration's logs. Useful for troubleshooting BLE communication issues."
         }
       }

--- a/custom_components/etekcity_fitness_scale_ble/translations/en.json
+++ b/custom_components/etekcity_fitness_scale_ble/translations/en.json
@@ -201,8 +201,8 @@
           "enable_library_logging": "Enable Library Logging"
         },
         "data_description": {
-          "history_retention_days": "How many days to keep weight measurements. Older measurements will be automatically removed. Range: 1-365 days.",
-          "max_history_size": "Maximum number of measurements to store per user. When exceeded, oldest measurements are removed. Range: 10-1000 measurements.",
+          "history_retention_days": "How many days to keep weight measurements. Older measurements will be automatically removed. Range: 0-365 days (0 = never delete by age).",
+          "max_history_size": "Maximum number of measurements to store per user. When exceeded, oldest measurements are removed. Range: 0-1000 measurements (0 = unlimited).",
           "enable_library_logging": "When enabled, logs from the underlying etekcity_esf551_ble library will be included in the integration's logs. Useful for troubleshooting BLE communication issues."
         }
       }


### PR DESCRIPTION
Adds an "unlimited" option to the two history-pruning settings so a user can keep their full measurement history.

## What changes
- History retention (days) and max history size now accept `0`, meaning no limit.
- `0` retention days: measurements are never pruned by age.
- `0` max history size: every measurement is kept, with no count cap.
- The config-flow range minimums drop from 1 and 10 to 0, and the strings and translations describe the `0 = unlimited` behavior.

## Behavior
`_cleanup_history` skips the age prune when retention is `0` and skips the count cap when max size is `0`. Non-zero values prune exactly as before, and the defaults are unchanged, so existing installs keep their current pruning.
