### PR TITLE
Add ESF-37 to the manual model picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This custom integration allows you to connect your Etekcity Bluetooth Low Energy
 
 ## Features
 
-- **Supported models:** ESF-551 (full features: weight, impedance, body composition), FIT-8S (weight, impedance, body composition; experimental), ESF-24 (weight, impedance, body composition; experimental), EFS-A591S-KUS / Apex HR (weight, impedance, body composition, heart rate; experimental) and EFS-C651 (weight, impedance, body composition; experimental)
+- **Supported models:** ESF-551 (full features: weight, impedance, body composition), FIT-8S (weight, impedance, body composition; experimental), ESF-24 (weight, impedance, body composition; experimental), EFS-A591S-KUS / Apex HR (weight, impedance, body composition, heart rate; experimental), EFS-C651 (weight, impedance, body composition; experimental) and ESF-37 (weight only; experimental)
 - Automatic discovery of Etekcity BLE fitness scales
 - Intelligent multi-user support:
     - Automatically detects which person is using the scale based on their weight history.
@@ -192,6 +192,7 @@ This integration supports the following Etekcity scale models:
 | [ESF-24 Smart Fitness Scale](https://us.vesync.com/product-detail/etekcity-esf24-smart-fitness-scale-335) | Experimental | Weight, impedance, body composition, display unit |
 | [EFS-A591S-KUS (Apex HR)](https://etekcity.com/collections/fitness-scales/products/hr-smart-fitness-scale) | Experimental | Weight, impedance, body composition, heart rate, display unit |
 | [EFS-C651 Smart Fitness Scale](https://etekcity.com/collections/fitness-scales/products/cobra-dark-blue) | Experimental | Weight, impedance, body composition (own algorithm), display unit |
+| ESF-37 Smart Fitness Scale | Experimental | Weight only (scale sends both kg and lb over BLE) |
 
 Other Etekcity BLE fitness scale models may work but have not been tested. If you'd like to help diagnose protocol compatibility for an unsupported model, see [Diagnosing Protocol Compatibility](#diagnosing-protocol-compatibility).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This custom integration allows you to connect your Etekcity Bluetooth Low Energy
 
 ## Features
 
-- **Supported models:** ESF-551 (full features: weight, impedance, body composition), FIT-8S (weight, impedance, body composition; experimental), ESF-24 (weight, impedance, body composition; experimental), EFS-A591S-KUS / Apex HR (weight, impedance, body composition, heart rate; experimental), EFS-C651 (weight, impedance, body composition; experimental) and ESF-37 (weight only; experimental)
+- **Supported models:** ESF-551 (full features: weight, impedance, body composition), FIT-8S (weight, impedance, body composition; experimental), ESF-24 (weight, impedance, body composition; experimental), EFS-A591S-KUS / Apex HR (weight, impedance, body composition, heart rate; experimental), EFS-C651 (weight, impedance, body composition; experimental) and ESF-37 (weight + body fat %; experimental)
 - Automatic discovery of Etekcity BLE fitness scales
 - Intelligent multi-user support:
     - Automatically detects which person is using the scale based on their weight history.
@@ -192,7 +192,7 @@ This integration supports the following Etekcity scale models:
 | [ESF-24 Smart Fitness Scale](https://us.vesync.com/product-detail/etekcity-esf24-smart-fitness-scale-335) | Experimental | Weight, impedance, body composition, display unit |
 | [EFS-A591S-KUS (Apex HR)](https://etekcity.com/collections/fitness-scales/products/hr-smart-fitness-scale) | Experimental | Weight, impedance, body composition, heart rate, display unit |
 | [EFS-C651 Smart Fitness Scale](https://etekcity.com/collections/fitness-scales/products/cobra-dark-blue) | Experimental | Weight, impedance, body composition (own algorithm), display unit |
-| ESF-37 Smart Fitness Scale | Experimental | Weight only (scale sends both kg and lb over BLE) |
+| ESF-37 Smart Fitness Scale | Experimental | Weight (scale sends both kg and lb over BLE) + body fat % (scale computes this on-device; no other body composition is available, see below) |
 
 Other Etekcity BLE fitness scale models may work but have not been tested. If you'd like to help diagnose protocol compatibility for an unsupported model, see [Diagnosing Protocol Compatibility](#diagnosing-protocol-compatibility).
 

--- a/custom_components/etekcity_fitness_scale_ble/config_flow.py
+++ b/custom_components/etekcity_fitness_scale_ble/config_flow.py
@@ -173,6 +173,7 @@ _MODEL_CHOICES: dict[str, str] = {
     ScaleModel.EFSC651.value: "EFS-C651",
     ScaleModel.ESF24.value: "ESF-24",
     ScaleModel.FIT8S.value: "FIT-8S",
+    ScaleModel.ESF37.value: "ESF-37 — weight only, experimental",
 }
 
 

--- a/custom_components/etekcity_fitness_scale_ble/coordinator.py
+++ b/custom_components/etekcity_fitness_scale_ble/coordinator.py
@@ -2509,7 +2509,21 @@ class ScaleDataUpdateCoordinator:
 
         # Create timestamp ONCE when measurement is received
         # This ensures consistent timestamps across all code paths (auto-assign, detection, pending)
-        measurement_timestamp = datetime.now().isoformat()
+        # data.timestamp is set for a history-batch record (e.g. ESF-37
+        # flushing its stored backlog on connect) to when that reading
+        # actually happened, as a timezone-aware UTC ISO string -- convert
+        # to local-naive to match every other timestamp in this pipeline
+        # rather than mixing formats. None (the live-reading case, same as
+        # before this field existed) just uses now().
+        if data.timestamp:
+            measurement_timestamp = (
+                datetime.fromisoformat(data.timestamp)
+                .astimezone()
+                .replace(tzinfo=None)
+                .isoformat()
+            )
+        else:
+            measurement_timestamp = datetime.now().isoformat()
 
         # Smart detection logic: Single user auto-assign (skip detection)
         if len(self._user_profiles) == 1:

--- a/custom_components/etekcity_fitness_scale_ble/coordinator.py
+++ b/custom_components/etekcity_fitness_scale_ble/coordinator.py
@@ -2339,7 +2339,8 @@ class ScaleDataUpdateCoordinator:
             data: The scale data containing all measurements.
 
         Returns:
-            Dictionary with only raw measurements (weight, impedance, heart_rate).
+            Dictionary with only raw measurements (weight, impedance,
+            heart_rate, body_fat_percentage).
         """
         raw_measurements = {}
         if "weight" in data.measurements:
@@ -2348,6 +2349,14 @@ class ScaleDataUpdateCoordinator:
             raw_measurements["impedance"] = data.measurements["impedance"]
         if "heart_rate" in data.measurements:
             raw_measurements["heart_rate"] = data.measurements["heart_rate"]
+        if "body_fat_percentage" in data.measurements:
+            # ESF-37 only: the scale computes this on-device and reports it
+            # directly, unlike every other model's body_fat_percentage
+            # (computed later from impedance + profile, so deliberately
+            # excluded here same as the rest of that cascade).
+            raw_measurements["body_fat_percentage"] = data.measurements[
+                "body_fat_percentage"
+            ]
         return raw_measurements
 
     def _validate_measurement(

--- a/custom_components/etekcity_fitness_scale_ble/manifest.json
+++ b/custom_components/etekcity_fitness_scale_ble/manifest.json
@@ -55,7 +55,7 @@
     "etekcity_esf551_ble"
   ],
   "requirements": [
-    "etekcity_esf551_ble==0.8.3"
+    "etekcity_esf551_ble @ git+https://github.com/kolonuk/etekcity_esf551_ble.git@esf37-support"
   ],
   "version": "0.8.0"
 }

--- a/custom_components/etekcity_fitness_scale_ble/sensor.py
+++ b/custom_components/etekcity_fitness_scale_ble/sensor.py
@@ -49,18 +49,20 @@ from .coordinator import ScaleData, ScaleDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+BODY_FAT_PERCENTAGE_DESCRIPTION = SensorEntityDescription(
+    key="body_fat_percentage",
+    icon="mdi:human-handsdown",
+    native_unit_of_measurement=PERCENTAGE,
+    state_class=SensorStateClass.MEASUREMENT,
+)
+
 SENSOR_DESCRIPTIONS = [
     SensorEntityDescription(
         key="body_mass_index",
         icon="mdi:human-male-height-variant",
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
-        key="body_fat_percentage",
-        icon="mdi:human-handsdown",
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
+    BODY_FAT_PERCENTAGE_DESCRIPTION,
     SensorEntityDescription(
         key="fat_free_weight",
         icon="mdi:run",
@@ -293,6 +295,25 @@ async def async_setup_entry(
                             native_unit_of_measurement="bpm",
                             state_class=SensorStateClass.MEASUREMENT,
                         ),
+                        user_id=user_id,
+                        user_name=user_name,
+                    ),
+                )
+
+            # The ESF-37 computes body fat % on-device and reports only that
+            # one figure directly - no impedance, so it can't run the
+            # BodyMetrics/BodyMetricsV2 cascade the other BODY_METRICS_MODELS
+            # scales use (that needs impedance + profile to derive all ten
+            # metrics). Treated like heart rate above: a direct measurement,
+            # not a computed one, so it's added independently of
+            # body_metrics_enabled.
+            if scale_model is ScaleModel.ESF37:
+                user_entities.append(
+                    ScaleUserSensor(
+                        entry.title,
+                        address,
+                        coordinator,
+                        BODY_FAT_PERCENTAGE_DESCRIPTION,
                         user_id=user_id,
                         user_name=user_name,
                     ),

--- a/custom_components/etekcity_fitness_scale_ble/sensor.py
+++ b/custom_components/etekcity_fitness_scale_ble/sensor.py
@@ -307,7 +307,7 @@ async def async_setup_entry(
             # metrics). Treated like heart rate above: a direct measurement,
             # not a computed one, so it's added independently of
             # body_metrics_enabled.
-            if scale_model is ScaleModel.ESF37:
+            if scale_model == ScaleModel.ESF37:
                 user_entities.append(
                     ScaleUserSensor(
                         entry.title,


### PR DESCRIPTION
Companion to ronnnnnnnnnnnnn/etekcity_esf551_ble#14, which adds ESF-37 (weight-only) support to the underlying library.

Adds ESF-37 to the manual model picker's label dict. No advertisement signature was captured for this model, so it isn't auto-discovered — manual picker only, same path as any other unclassified device.

Since the scale needs no onboard user-profile selection (see the library PR for why), person disambiguation for ESF-37 users works the same as any other model here: this integration's own weight-history matching, not anything scale-side.

Requirements pin isn't bumped — depends on a etekcity_esf551_ble release that includes ESF-37, which hasn't shipped yet.
